### PR TITLE
잘못된 도메인 정보 바로잡기

### DIFF
--- a/src/main/java/com/bokyoung/workboardproject/domain/UserAccount.java
+++ b/src/main/java/com/bokyoung/workboardproject/domain/UserAccount.java
@@ -10,7 +10,7 @@ import java.util.Objects;
 @Getter
 @ToString
 @Table(indexes = {
-        @Index(columnList = "userId"),
+        @Index(columnList = "userId", unique = true),
         @Index(columnList = "email", unique = true),
         @Index(columnList = "createdAt"),
         @Index(columnList = "createdBy")

--- a/src/test/java/com/bokyoung/workboardproject/repository/JpaRepositoryTest.java
+++ b/src/test/java/com/bokyoung/workboardproject/repository/JpaRepositoryTest.java
@@ -56,7 +56,7 @@ class JpaRepositoryTest {
 
         //given
         long preCount = articleRepository.count();
-        UserAccount userAccount = userAccountRepository.save(UserAccount.of("uno", "pw", null, null, null));
+        UserAccount userAccount = userAccountRepository.save(UserAccount.of("newShin", "pw", null, null, null));
         Article article = Article.of(userAccount, "new article", "new content", "#spring");
 
         //when


### PR DESCRIPTION
#29 기능을 하다가 도메인 코드 설계가 일부 잘못 되어있는 것을 발견.
UserAccount 회원 계정의 userId 는 회원 id 이므로 유니크해야 하는데,
해당 속성이 빠져있었다.
erd 문서에는 email 의 유니크 키가 표현되지 않음
바로잡기로 한다.

- [x] user_id에 유니크 키 추가
- [x] email erd 업데이트