### PR TITLE
엔티티 equals() 버그 수정

### DIFF
--- a/src/main/java/com/bokyoung/workboardproject/domain/Article.java
+++ b/src/main/java/com/bokyoung/workboardproject/domain/Article.java
@@ -63,9 +63,8 @@ public class Article extends AuditingFields {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        Article article = (Article) o;
-        return id.equals(article.id);
+        if (!(o instanceof Article that)) return false;
+        return id != null && id.equals(that.getId());
     }
 
     @Override

--- a/src/main/java/com/bokyoung/workboardproject/domain/ArticleComment.java
+++ b/src/main/java/com/bokyoung/workboardproject/domain/ArticleComment.java
@@ -50,9 +50,8 @@ public class ArticleComment extends AuditingFields{
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        ArticleComment that = (ArticleComment) o;
-        return id.equals(that.id);
+        if (!(o instanceof ArticleComment that)) return false;
+        return id != null && id.equals(that.getId());
     }
 
     @Override

--- a/src/main/java/com/bokyoung/workboardproject/domain/UserAccount.java
+++ b/src/main/java/com/bokyoung/workboardproject/domain/UserAccount.java
@@ -54,10 +54,8 @@ public class UserAccount extends AuditingFields{
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        UserAccount that = (UserAccount) o;
-        return Objects.equals(userId, that.userId);
+        if (!(o instanceof UserAccount that)) return false;
+        return userId != null && userId.equals(that.getUserId());
     }
 
     @Override


### PR DESCRIPTION
테스트해 보니 `that.id`와 같은 표현은
의도하지 않은 동작을 만들었다.
제대로 getter 를 써서 값을 불러오게 수정
이름도 `that`으로 통일

This closes #47 